### PR TITLE
feat(tinyxml2-go): add input-size, node-count, and nesting-depth limits (DoS protection)

### DIFF
--- a/docs/BUG_JOURNAL.md
+++ b/docs/BUG_JOURNAL.md
@@ -6,6 +6,7 @@
 - **Fuzz test token bounds check on error**: When a parser fails partway through, partial tokens with End=-1 remain accessible via Tokens(). Fuzz tests that validate token bounds must skip the check when Parse() returns an error, or the test will report false positives.
 - **Size-gated parallel code path in tests**: If parallel processing only activates above a byte threshold (e.g. >4096 bytes), test data must exceed that threshold or the parallel path is never exercised and coverage is misleadingly low.
 - **OO API fuzz test referencing wrong API**: Auto-generated fuzz tests can reference an OO-style API (NewDocument/doc.Parse) when the actual package exposes a functional API (Parse(data) (*Doc, error)). Always compile-check fuzz tests before merging.
+- **Unbounded recursive parser = stack-overflow DoS**: Recursive descent parsers (XML elements, JSON values) that recurse once per nesting level will exhaust the stack on adversarial deeply-nested input. Guard with a MaxNestingDepth limit checked at the top of the recursive function, plus MaxInputSize and a shared MaxNodeCount counter. Follow the jsmn-go Config pattern (DefaultConfig/StrictConfig/UnlimitedConfig + sentinel errors via errors.Is); add limits as a NEW ParseWithConfig entrypoint so the existing Parse signature stays back-compatible.
 
 ## Chronological Log
 

--- a/tinyxml2-go/config.go
+++ b/tinyxml2-go/config.go
@@ -1,0 +1,91 @@
+// Package tinyxml2go provides a concurrent XML DOM parser with optional
+// DoS-protection limits (input size, node count, nesting depth).
+package tinyxml2go
+
+import "errors"
+
+// Common errors returned by configured parsing.
+var (
+	// ErrInputTooLarge is returned when input exceeds Config.MaxInputSize.
+	ErrInputTooLarge = errors.New("input size exceeds maximum allowed")
+
+	// ErrTooManyNodes is returned when the parsed node count exceeds Config.MaxNodeCount.
+	ErrTooManyNodes = errors.New("node count exceeds maximum allowed")
+
+	// ErrNestingTooDeep is returned when element nesting exceeds Config.MaxNestingDepth.
+	ErrNestingTooDeep = errors.New("nesting depth exceeds maximum allowed")
+
+	// ErrEmptyInput is returned when input is empty.
+	ErrEmptyInput = errors.New("empty input")
+)
+
+// Config holds parsing limits used to guard against malicious or oversized
+// input (DoS protection). The zero value of any individual limit means
+// "unlimited" for that dimension; prefer DefaultConfig or StrictConfig for
+// untrusted input.
+type Config struct {
+	// MaxInputSize limits the maximum XML input size in bytes.
+	// Default: 100MB. Set to 0 for unlimited (not recommended).
+	MaxInputSize int
+
+	// MaxNodeCount limits the maximum number of element nodes parsed.
+	// Default: 1,000,000. Set to 0 for unlimited (not recommended).
+	MaxNodeCount int
+
+	// MaxNestingDepth limits how deeply elements may nest. This prevents
+	// stack exhaustion from deeply nested XML.
+	// Default: 1,000. Set to 0 for unlimited (not recommended).
+	MaxNestingDepth int
+}
+
+// DefaultConfig returns the default configuration with sensible limits.
+func DefaultConfig() *Config {
+	return &Config{
+		MaxInputSize:    100 * 1024 * 1024, // 100MB
+		MaxNodeCount:    1_000_000,         // 1 million nodes
+		MaxNestingDepth: 1_000,             // 1000 levels deep
+	}
+}
+
+// StrictConfig returns a stricter configuration suitable for untrusted input.
+func StrictConfig() *Config {
+	return &Config{
+		MaxInputSize:    10 * 1024 * 1024, // 10MB
+		MaxNodeCount:    100_000,          // 100k nodes
+		MaxNestingDepth: 100,              // 100 levels deep
+	}
+}
+
+// UnlimitedConfig returns a configuration with no limits (use with caution).
+func UnlimitedConfig() *Config {
+	return &Config{
+		MaxInputSize:    0, // Unlimited
+		MaxNodeCount:    0, // Unlimited
+		MaxNestingDepth: 0, // Unlimited
+	}
+}
+
+// Validate checks that the configuration values are not negative.
+func (c *Config) Validate() error {
+	if c.MaxInputSize < 0 {
+		return errors.New("MaxInputSize cannot be negative")
+	}
+	if c.MaxNodeCount < 0 {
+		return errors.New("MaxNodeCount cannot be negative")
+	}
+	if c.MaxNestingDepth < 0 {
+		return errors.New("MaxNestingDepth cannot be negative")
+	}
+	return nil
+}
+
+// validateInput checks that the input meets the size constraints.
+func (c *Config) validateInput(data []byte) error {
+	if len(data) == 0 {
+		return ErrEmptyInput
+	}
+	if c.MaxInputSize > 0 && len(data) > c.MaxInputSize {
+		return ErrInputTooLarge
+	}
+	return nil
+}

--- a/tinyxml2-go/config_test.go
+++ b/tinyxml2-go/config_test.go
@@ -1,0 +1,198 @@
+package tinyxml2go
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestParseWithConfig_NilUsesDefault(t *testing.T) {
+	xml := `<?xml version="1.0"?><root attr="val"><child>text</child></root>`
+	doc, err := ParseWithConfig([]byte(xml), nil)
+	if err != nil {
+		t.Fatalf("ParseWithConfig() with nil config failed: %v", err)
+	}
+	if doc.Root.Name != "root" {
+		t.Fatalf("expected root, got %s", doc.Root.Name)
+	}
+	if doc.Root.Children[0].Text != "text" {
+		t.Fatalf("child text mismatch: %q", doc.Root.Children[0].Text)
+	}
+}
+
+func TestParseWithConfig_EmptyInput(t *testing.T) {
+	_, err := ParseWithConfig([]byte(""), DefaultConfig())
+	if !errors.Is(err, ErrEmptyInput) {
+		t.Fatalf("expected ErrEmptyInput, got %v", err)
+	}
+}
+
+func TestParseWithConfig_InputTooLarge(t *testing.T) {
+	xml := []byte(`<root><child>text</child></root>`)
+	cfg := &Config{MaxInputSize: 10} // far smaller than input
+	_, err := ParseWithConfig(xml, cfg)
+	if !errors.Is(err, ErrInputTooLarge) {
+		t.Fatalf("expected ErrInputTooLarge, got %v", err)
+	}
+}
+
+func TestParseWithConfig_InputSizeBoundary(t *testing.T) {
+	xml := []byte(`<a/>`)
+	// Exactly at the limit must succeed.
+	if _, err := ParseWithConfig(xml, &Config{MaxInputSize: len(xml)}); err != nil {
+		t.Fatalf("input exactly at MaxInputSize should parse, got %v", err)
+	}
+	// One byte over the limit must fail.
+	if _, err := ParseWithConfig(xml, &Config{MaxInputSize: len(xml) - 1}); !errors.Is(err, ErrInputTooLarge) {
+		t.Fatalf("expected ErrInputTooLarge one byte over limit, got %v", err)
+	}
+}
+
+func TestParseWithConfig_TooManyNodes(t *testing.T) {
+	// 1 root + 3 children = 4 element nodes.
+	xml := []byte(`<root><a/><b/><c/></root>`)
+	cfg := &Config{MaxNodeCount: 3}
+	_, err := ParseWithConfig(xml, cfg)
+	if !errors.Is(err, ErrTooManyNodes) {
+		t.Fatalf("expected ErrTooManyNodes, got %v", err)
+	}
+
+	// Exactly at the node limit must succeed.
+	if _, err := ParseWithConfig(xml, &Config{MaxNodeCount: 4}); err != nil {
+		t.Fatalf("4 nodes with MaxNodeCount=4 should succeed, got %v", err)
+	}
+}
+
+func TestParseWithConfig_NestingTooDeep(t *testing.T) {
+	// Build deeply nested XML: <n0><n1>...<n49/></n1></n0> = depth 50.
+	const depth = 50
+	var sb strings.Builder
+	for i := 0; i < depth; i++ {
+		sb.WriteString("<n>")
+	}
+	for i := 0; i < depth; i++ {
+		sb.WriteString("</n>")
+	}
+	xml := []byte(sb.String())
+
+	// Limit below actual depth must fail with ErrNestingTooDeep.
+	if _, err := ParseWithConfig(xml, &Config{MaxNestingDepth: 10}); !errors.Is(err, ErrNestingTooDeep) {
+		t.Fatalf("expected ErrNestingTooDeep, got %v", err)
+	}
+
+	// Limit at exactly the actual depth must succeed.
+	if _, err := ParseWithConfig(xml, &Config{MaxNestingDepth: depth}); err != nil {
+		t.Fatalf("depth==limit should succeed, got %v", err)
+	}
+
+	// Limit one below the actual depth must fail.
+	if _, err := ParseWithConfig(xml, &Config{MaxNestingDepth: depth - 1}); !errors.Is(err, ErrNestingTooDeep) {
+		t.Fatalf("expected ErrNestingTooDeep at depth-1, got %v", err)
+	}
+}
+
+func TestParseWithConfig_UnlimitedAllowsDeepNesting(t *testing.T) {
+	const depth = 500
+	var sb strings.Builder
+	for i := 0; i < depth; i++ {
+		sb.WriteString("<n>")
+	}
+	for i := 0; i < depth; i++ {
+		sb.WriteString("</n>")
+	}
+	xml := []byte(sb.String())
+
+	doc, err := ParseWithConfig(xml, UnlimitedConfig())
+	if err != nil {
+		t.Fatalf("UnlimitedConfig should parse deep nesting, got %v", err)
+	}
+	// Walk to the bottom to confirm the full tree was built.
+	n := doc.Root
+	got := 1
+	for len(n.Children) == 1 {
+		n = n.Children[0]
+		got++
+	}
+	if got != depth {
+		t.Fatalf("expected nesting depth %d, walked %d", depth, got)
+	}
+}
+
+func TestConfig_Presets(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  *Config
+	}{
+		{"Default", DefaultConfig()},
+		{"Strict", StrictConfig()},
+		{"Unlimited", UnlimitedConfig()},
+	} {
+		if err := tc.cfg.Validate(); err != nil {
+			t.Errorf("%s config should validate, got %v", tc.name, err)
+		}
+	}
+
+	// Strict is tighter than Default on every dimension.
+	d, s := DefaultConfig(), StrictConfig()
+	if s.MaxInputSize >= d.MaxInputSize || s.MaxNodeCount >= d.MaxNodeCount || s.MaxNestingDepth >= d.MaxNestingDepth {
+		t.Error("StrictConfig should be tighter than DefaultConfig on all limits")
+	}
+}
+
+func TestConfig_ValidateNegative(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  *Config
+	}{
+		{"NegInputSize", &Config{MaxInputSize: -1}},
+		{"NegNodeCount", &Config{MaxNodeCount: -1}},
+		{"NegNestingDepth", &Config{MaxNestingDepth: -1}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.cfg.Validate(); err == nil {
+				t.Error("expected validation error for negative limit")
+			}
+		})
+	}
+}
+
+func TestParseWithConfig_InvalidConfigRejected(t *testing.T) {
+	_, err := ParseWithConfig([]byte(`<root/>`), &Config{MaxInputSize: -5})
+	if err == nil {
+		t.Fatal("expected error for invalid config, got nil")
+	}
+	if errors.Is(err, ErrEmptyInput) || errors.Is(err, ErrInputTooLarge) {
+		t.Fatalf("expected config validation error, got input error: %v", err)
+	}
+}
+
+// TestParseWithConfig_MatchesParse confirms ParseWithConfig builds the same
+// tree as the legacy Parse for valid input within limits.
+func TestParseWithConfig_MatchesParse(t *testing.T) {
+	xml := []byte(`<?xml version="1.0"?>
+<library>
+	<book id="1"><title>A</title></book>
+	<book id="2"><title>B</title></book>
+</library>`)
+
+	got, err := ParseWithConfig(xml, DefaultConfig())
+	if err != nil {
+		t.Fatalf("ParseWithConfig() failed: %v", err)
+	}
+	want, err := Parse(xml)
+	if err != nil {
+		t.Fatalf("Parse() failed: %v", err)
+	}
+
+	gb := got.Root.FindAll("book")
+	wb := want.Root.FindAll("book")
+	if len(gb) != len(wb) || len(gb) != 2 {
+		t.Fatalf("book count mismatch: got %d, want %d", len(gb), len(wb))
+	}
+	if gb[1].GetAttribute("id") != wb[1].GetAttribute("id") {
+		t.Error("attribute mismatch between ParseWithConfig and Parse")
+	}
+	if gb[0].Find("title").Text != "A" {
+		t.Errorf("title mismatch: %q", gb[0].Find("title").Text)
+	}
+}

--- a/tinyxml2-go/tinyxml2.go
+++ b/tinyxml2-go/tinyxml2.go
@@ -62,6 +62,119 @@ func Parse(data []byte) (*XMLDocument, error) {
 	return nil, errors.New("no root element found")
 }
 
+// ParseWithConfig builds a full DOM tree while enforcing the limits in config
+// (input size, total node count, and nesting depth) to guard against
+// denial-of-service from oversized or maliciously nested XML.
+//
+// If config is nil, DefaultConfig is used. The original Parse function is
+// unchanged and applies no limits; use ParseWithConfig for untrusted input.
+func ParseWithConfig(data []byte, config *Config) (*XMLDocument, error) {
+	if config == nil {
+		config = DefaultConfig()
+	}
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+	if err := config.validateInput(data); err != nil {
+		return nil, err
+	}
+
+	dec := xml.NewDecoder(bytes.NewReader(data))
+	doc := &XMLDocument{}
+	nodeCount := 0
+
+	for {
+		tok, err := dec.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		switch v := tok.(type) {
+		case xml.ProcInst:
+			if v.Target == "xml" {
+				doc.Declaration = fmt.Sprintf("<?%s %s?>", v.Target, string(v.Inst))
+			}
+		case xml.Comment:
+			// Skip
+		case xml.StartElement:
+			root, err := parseElementLimited(dec, v, config, 1, &nodeCount)
+			if err != nil {
+				return nil, err
+			}
+			doc.Root = root
+			return doc, nil
+		}
+	}
+
+	return nil, errors.New("no root element found")
+}
+
+// parseElementLimited mirrors parseElement but enforces depth and node-count
+// limits. depth is the depth of se (root == 1). nodeCount is shared across the
+// whole document and incremented once per element node.
+func parseElementLimited(
+	dec *xml.Decoder,
+	se xml.StartElement,
+	config *Config,
+	depth int,
+	nodeCount *int,
+) (*Node, error) {
+	if config.MaxNestingDepth > 0 && depth > config.MaxNestingDepth {
+		return nil, ErrNestingTooDeep
+	}
+
+	*nodeCount++
+	if config.MaxNodeCount > 0 && *nodeCount > config.MaxNodeCount {
+		return nil, ErrTooManyNodes
+	}
+
+	node := &Node{
+		Name:       se.Name.Local,
+		Attributes: make(map[string]string),
+	}
+
+	for _, a := range se.Attr {
+		node.Attributes[a.Name.Local] = a.Value
+	}
+
+	for {
+		tok, err := dec.Token()
+		if err == io.EOF {
+			return nil, errors.New("unexpected EOF")
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		switch v := tok.(type) {
+		case xml.StartElement:
+			child, err := parseElementLimited(dec, v, config, depth+1, nodeCount)
+			if err != nil {
+				return nil, err
+			}
+			node.Children = append(node.Children, child)
+
+		case xml.CharData:
+			text := strings.TrimSpace(string(v))
+			if text != "" {
+				if node.Text == "" {
+					node.Text = text
+				} else {
+					node.Text += text
+				}
+			}
+
+		case xml.EndElement:
+			if v.Name.Local == se.Name.Local {
+				return node, nil
+			}
+		}
+	}
+}
+
 // The recursive parseElement helper needs only a minor change
 // to remove the 'parser' struct dependency.
 // func parseElement(dec *xml.Decoder, se xml.StartElement) (*Node, error) { ... }


### PR DESCRIPTION
## What

Adds DoS-protection limits to `tinyxml2-go` via a new, additive `Config` API:

- **`config.go`**: `Config{MaxInputSize, MaxNodeCount, MaxNestingDepth}` with presets `DefaultConfig()` (100MB / 1M nodes / 1000 deep), `StrictConfig()` (10MB / 100k / 100), and `UnlimitedConfig()`; a `Validate()` method; and sentinel errors `ErrInputTooLarge`, `ErrTooManyNodes`, `ErrNestingTooDeep`, `ErrEmptyInput` (all `errors.Is`-friendly).
- **`tinyxml2.go`**: new `ParseWithConfig(data []byte, config *Config) (*XMLDocument, error)` plus a depth/count-aware `parseElementLimited`. The existing `Parse(data)` signature is **unchanged** (applies no limits) — fully backward compatible.

## Why

`ISSUES.md` #5 ("No Input Size Limits — DoS Risk", Medium/Security) explicitly names tinyxml2-go: *"No maximum node count"* and *"Deeply nested XML → stack overflow or memory exhaustion."* The previous parser accepted unbounded input and recursed once per nesting level with no depth cap — a real stack-exhaustion DoS on adversarial input.

This follows the convention already established in `jsmn-go` (`Config` + `DefaultConfig/StrictConfig/UnlimitedConfig` + sentinel errors) and the three-tier validation described in `ARCHITECTURE.md` → *Security Architecture* (size, node count, depth).

**Roadmap source:** `ISSUES.md` Issue #5 (also referenced in Phase 2 "Add input size limits").

## How tested

New `config_test.go` proves each limit at its boundary (at-limit succeeds, one-over returns the matching sentinel via `errors.Is`), nil-config defaulting, invalid-config rejection, `UnlimitedConfig` deep nesting (500 levels), and that `ParseWithConfig` produces the same tree as legacy `Parse`.

Gate (all green):
- `go build ./...`, `go vet ./...`, `go test ./...` per module; `make vet` and `make test` pass
- `go test -race ./...` on tinyxml2-go clean
- `gofmt` clean; `golangci-lint` introduces **no new findings** in the added code (remaining findings are pre-existing in `tinyxml2_bench.go` and the original `Parse`/`parseElement`)

A bug-journal entry (`docs/BUG_JOURNAL.md`) was added in the same commit capturing the generalizable "unbounded recursive parser = stack-overflow DoS" pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new parsing method with configurable limits on input size, node count, and element nesting depth.
  * Introduced preset configuration options (default, strict, unlimited) for flexible limit selection.
  * New error types indicating limit violations or invalid input.

* **Documentation**
  * Added notes documenting recommended parsing patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->